### PR TITLE
fix unhandled exception on tls socket upgrade when underlying connect…

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -124,7 +124,13 @@ Connection.prototype.connect = function() {
   }
 
   if (config.tls)
-    this._sock = tls.connect(tlsOptions, onconnect);
+    try {
+      this._sock = tls.connect(tlsOptions, onconnect);
+    } catch (e) {//happens when socket hangs up
+      e.source = 'tls-connect';
+      self.emit('error', e);
+      socket.destroy();
+    }
   else {
     socket.once('connect', onconnect);
     this._sock = socket;


### PR DESCRIPTION
…ion has been reset

try to resolve this:

```
Error: socket hang up
 at Connection.connect (/usr/src/app/node_modules/imap/lib/Connection.js:127:22)
```

it is possible this try/catch won't fix the issue... if it doesn't I'll revert this and make a different fix.
